### PR TITLE
Adding lat/lng

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ humandate: Mar 10-11 2014
 humantime: 9:00 am - 4:30 pm
 startdate: 2014-03-10
 enddate: 2014-03-11
-latlng: 
+latlng: 38.035,-78.505
 registration: restricted
 instructor: ["Michael Hansen", "Stephen Turner", "Erik Bray"]
 contact: admin@software-carpentry.org


### PR DESCRIPTION
Added a lat/lng value because having the field empty is making our website build barf.
